### PR TITLE
feat: delete word

### DIFF
--- a/frontend/src/features/reviewWords/components/word-list.tsx
+++ b/frontend/src/features/reviewWords/components/word-list.tsx
@@ -29,7 +29,7 @@ export default function WordList() {
       }
     };
     handleWord();
-  }, [words]);
+  }, []);
 
   const deleteWord = async (id: number) => {
     try {

--- a/frontend/src/features/reviewWords/components/word-list.tsx
+++ b/frontend/src/features/reviewWords/components/word-list.tsx
@@ -12,6 +12,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import Link from "next/link";
+import { Button } from "@/components/ui/button";
 
 export default function WordList() {
   const [words, setWords] = useState<Word[]>([]);
@@ -28,7 +29,17 @@ export default function WordList() {
       }
     };
     handleWord();
-  }, []);
+  }, [words]);
+
+  const deleteWord = async (id: number) => {
+    try {
+      await invoke("delete_word", { id });
+      setWords(words.filter((word) => word.id !== id));
+    } catch (error) {
+      console.error("Failed to delete word:", error);
+      setError(`Error: ${error}`);
+    }
+  };
 
   return (
     <div className="p-4">
@@ -41,7 +52,9 @@ export default function WordList() {
             {words.map((word) => (
               <Card key={word.id} className="my-1">
                 <CardHeader>
-                  <CardTitle>{word.vocabulary}</CardTitle>
+                  <CardTitle>
+                    {word.vocabulary} (id: {word.id})
+                  </CardTitle>
                   <CardDescription>カテゴリ: {word.category}</CardDescription>
                 </CardHeader>
                 <CardContent>
@@ -52,6 +65,7 @@ export default function WordList() {
                     {word.example && (
                       <div className="text-sm italic">例: {word.example}</div>
                     )}
+                    <Button onClick={() => deleteWord(word.id)}>削除</Button>
                   </div>
                 </CardFooter>
               </Card>


### PR DESCRIPTION
This pull request introduces functionality to delete words from the word list in the frontend and backend. The most important changes include adding a delete button to the frontend UI, implementing the `delete_word` function in the backend, and ensuring proper state management and error handling.

### Frontend Changes:
* **Added a delete button to the word list UI**: A `Button` component was imported and added to each word card, allowing users to delete a word by clicking the button. [[1]](diffhunk://#diff-13d4776bf7cd07dd92ed227275bca68261fcad4e92c2f6ac73728fc22130d35bR15) [[2]](diffhunk://#diff-13d4776bf7cd07dd92ed227275bca68261fcad4e92c2f6ac73728fc22130d35bR68)
* **Implemented `deleteWord` function**: A new function was added to make an asynchronous call to the backend `delete_word` command and update the state by removing the deleted word from the list.
* **Enhanced word display**: The word cards now display the word ID alongside the vocabulary for better identification.

### Backend Changes:
* **Implemented `delete_word` command**: The backend `delete_word` function was updated to remove a word by its ID, update the JSON file storing the words, and handle potential errors such as file locking and directory creation.